### PR TITLE
rubocop from production bundle and Rails cops gem added

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
     - config/**/*
     - bin/**/*
 
+require:
+  - rubocop-rails
+
 Layout/LineLength:
   Max: 120
 
@@ -22,9 +25,5 @@ Style/FrozenStringLiteralComment:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-Rails:
-  Enabled: true
-
 Rails/Date:
   Enabled: true
-

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :development, :test do
   gem 'rspec-its'
   gem 'rspec-rails'
   gem 'rubocop', '~> 0.79.0', require: false
+  gem 'rubocop-rails', require: false
   gem 'timecop'
   gem 'bullet'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -65,8 +65,8 @@ group :development, :test do
   gem 'rspec-collection_matchers'
   gem 'rspec-its'
   gem 'rspec-rails'
-  gem 'rubocop', '~> 0.79.0', require: false
-  gem 'rubocop-rails', require: false
+  gem 'rubocop', '~> 0.79.0'
+  gem 'rubocop-rails'
   gem 'timecop'
   gem 'bullet'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,6 +312,9 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-rails (2.4.2)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     rubyzip (2.2.0)
     sass (3.4.25)
@@ -437,6 +440,7 @@ DEPENDENCIES
   rspec-its
   rspec-rails
   rubocop (~> 0.79.0)
+  rubocop-rails
   sass-rails (~> 5.0.1)
   shoulda-matchers (~> 4.1)
   simple_form
@@ -452,4 +456,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
 - Removing gem from production into test and development
 - require: false to remove from bundle
 - readded rubocop-rails which were originally configured in
   the rubocop.yml but would have been lost when Rails cops
   were moved into rubocop-rails gem.
   - removed config which were enabled by default
 - rspec added (the cops seem to be set off by default)
 - performance added
 - adding basic codeclimate config